### PR TITLE
Update .gitignore to ignore user defined templates and themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,17 @@
 /uploads/logs/errors/*.log
 /uploads/rss/*.xml
 /uploads/users/nopicture.*
+
+/templates/*
+/themes/*
+
+\!/templates/base/
+\!/templates/clansphere/
+\!/templates/index.html
+
+\!/themes/base/
+\!/themes/clansphere/
+\!/themes/custom/
+\!/themes/.htaccess
+\!/themes/index.html
+\!/themes/web.config


### PR DESCRIPTION
An update of .gitignore following the specs of http://git-scm.com/docs/gitignore

"/templates/*" ignores everything in the folder (i.e. "my-template")

"!/templates/base/" unignores specified folder
